### PR TITLE
Upload captured video to youtube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# captured video
+*.ogv
+*.mp4

--- a/autotest/autotest.sh
+++ b/autotest/autotest.sh
@@ -89,6 +89,21 @@ function do_game(){
     VIDEO_NAME="${VIDEO_DIRECTORY_PATH}/"GAME_${DATE}_${ITERATION}_${ENEMY_LEVEL}_${GAME_TIME}_${MY_SCORE}_${ENEMY_SCORE}_${BATTLE_RESULT}_${MY_SIDE}".mp4"
     do_capture "stop" "$VIDEO_NAME"
 
+    # upload video to youtube if LOSE
+    if [ -f "${VIDEO_NAME}" ] && [ "${BATTLE_RESULT}" = "LOSE" ]; then
+	if which youtube-upload > /dev/null &&
+		[ -f "${HOME}/.client_secrets.json" ] &&
+		[ -f "${HOME}/.youtube-upload-credentials.json" ]; then
+	    local VIDEO_TITLE="$(basename ${VIDEO_NAME})"
+	    local VIDEO_ID=$(youtube-upload --title "${VIDEO_TITLE}" "${VIDEO_NAME}")
+	    if [ $? -eq 0 ]; then
+		send_slack_video "${VIDEO_TITLE}" "${VIDEO_ID}"
+	    fi
+	else
+	    echo "${FUNCNAME[0]}: ${LINENO}: youtube-upload is unavailable" > /dev/stderr
+	fi
+    fi
+
     ## reset
     #bash scripts/reset.sh
     #sleep 3


### PR DESCRIPTION
@seigot 
youtubeにAPI経由でアップロードするにあたり、
非公開になったり６回/日だったりと色々制約はあるのですが、
いまのところないよりはあったほうが良いのと、
本線に入れていただいたほうがメンテしやすいのでmergeしていただきたいです。

デフォルト無効で、
キャプチャ機能有効かつ、ゲームに負けて、youtube-uploadというツールの設定をしている場合のみ、
youtubeに動画をアップロードします。

youtube-uploadの設定は結構手間なので、
もうちょっと改善できるまでは実際自動でアップロードするのは私だけでいいかなと思ってます。
とはいえ私の備忘録を兼ねて、今のわかっている手順を下記に書いておきます。
（もちろん本家READMEが一番くわしいですが）
ざっくり下記の３ステップです。

1. インストール

```
$ sudo pip install --upgrade google-api-python-client oauth2client progressbar2
$ wget https://github.com/tokland/youtube-upload/archive/master.zip
$ unzip master.zip
$ cd youtube-upload-master
$ sudo python setup.py install
```

2. [GCPのコンソール](https://console.cloud.google.com/apis/credentials?folder=&organizationId=&project=robotics-hub-challenge)で`youtube-upload`用のclient secretを取得し、`~/.client_secrets.json`として保存する

3. 一回youtube-uploadを起動すると、ブラウザを使った認証を促されるので、手順に従い、`~/.youtube-upload-credentials.json`を生成する

[tokland/youtube-upload: Upload videos to Youtube from the command line](https://github.com/tokland/youtube-upload)