### PR TITLE
Locate gazebo camera pose just above the game field.

### DIFF
--- a/autotest/autotest.sh
+++ b/autotest/autotest.sh
@@ -32,7 +32,31 @@ pushd ${BURGER_WAR_KIT_REPOSITORY}
 source autotest/slack.sh
 popd
 
-# function
+function search_window() {
+    xdotool search --sync --onlyvisible --name "$1"
+}
+
+function adjust_layout() {
+    local -ir UNIT=700
+
+    # Gazebo window is shown with maximized
+    # Ref: https://stackoverflow.com/questions/23850499/how-to-move-or-resize-x11-windows-even-if-they-are-maximized
+    local -r GAZEBO=$(search_window "Gazebo")
+    wmctrl -i -r ${GAZEBO} -b remove,maximized_vert,maximized_horz
+    xdotool windowunmap --sync ${GAZEBO}
+    xdotool windowmap --sync ${GAZEBO}
+    wmctrl -i -r ${GAZEBO} -e 0,0,0,${UNIT},${UNIT}
+    xdotool windowactivate --sync ${GAZEBO}
+
+    local -r SCORE_BOARD=$(search_window "burger war")
+    wmctrl -i -r ${SCORE_BOARD} -e 0,0,${UNIT},${UNIT},${UNIT}
+    xdotool windowactivate --sync ${SCORE_BOARD}
+
+    local -r RVIZ=$(search_window "RViz")
+    wmctrl -i -r ${RVIZ} -e 0,${UNIT},0,${UNIT},$((2*${UNIT}))
+    xdotool windowactivate --sync ${RVIZ}
+}
+
 function do_game(){
     ITERATION=$1
     ENEMY_LEVEL=$2
@@ -57,6 +81,7 @@ function do_game(){
     fi
     # start
     gnome-terminal -- bash scripts/start.sh -l ${ENEMY_LEVEL} -a # -s ${MY_SIDE}
+    adjust_layout
 
     # wait game finish
     sleep $GAME_TIME

--- a/autotest/autotest.sh
+++ b/autotest/autotest.sh
@@ -56,7 +56,7 @@ function do_game(){
 	sleep 30
     fi
     # start
-    gnome-terminal -- bash scripts/start.sh -l ${ENEMY_LEVEL} # -s ${MY_SIDE}
+    gnome-terminal -- bash scripts/start.sh -l ${ENEMY_LEVEL} -a # -s ${MY_SIDE}
 
     # wait game finish
     sleep $GAME_TIME

--- a/autotest/autotest.sh
+++ b/autotest/autotest.sh
@@ -52,7 +52,7 @@ function do_game(){
     PROCESS_NUM=`ps -ux | grep "sim_with_judge.sh" | grep -v "grep"  | wc -l`
     if [ $PROCESS_NUM -eq 0 ]; then
 	# wakeup at once
-	gnome-terminal -- bash scripts/sim_with_judge.sh # -s ${MY_SIDE}
+	gnome-terminal -- bash scripts/sim_with_judge.sh -a # -s ${MY_SIDE}
 	sleep 30
     fi
     # start

--- a/burger_war/launch/sim_robot_run.launch
+++ b/burger_war/launch/sim_robot_run.launch
@@ -2,10 +2,12 @@
 <launch>
   <arg name="enemy_level" default="1"/>
   <arg name="side" default="r" />
+  <arg name="rviz_file" default="burger_navigation.rviz"/>
 
 <!-- Your robot control node run  red side-->
   <include file="$(find burger_war_dev)/launch/your_burger.launch">
     <arg name="side" value="r" />
+    <arg name="rviz_file" value="$(arg rviz_file)"/>
   </include>
 
 <!-- enemy bot run  blue side-->

--- a/burger_war/world/burger_field.world
+++ b/burger_war/world/burger_field.world
@@ -13,7 +13,7 @@
 
 <gui>
   <camera name="camera">
-    <pose>1.5 -5. 6. 0.0 .85 1.8</pose>
+    <pose>-0.03 0.13 2.76 0.0 1.57 2.26</pose>
     <view_controller>orbit</view_controller>
   </camera>
 </gui>

--- a/burger_war/world/burger_field.world
+++ b/burger_war/world/burger_field.world
@@ -13,7 +13,7 @@
 
 <gui>
   <camera name="camera">
-    <pose>-0.03 0.13 2.76 0.0 1.57 2.26</pose>
+    <pose>1.5 -5. 6. 0.0 .85 1.8</pose>
     <view_controller>orbit</view_controller>
   </camera>
 </gui>

--- a/burger_war/world/burger_field.world.em
+++ b/burger_war/world/burger_field.world.em
@@ -13,7 +13,7 @@
 
 <gui>
   <camera name="camera">
-    <pose>1.5 -5. 6. 0.0 .85 1.8</pose>
+    <pose>@(GUI_CAMERA_POSE $ "1.5 -5. 6. 0.0 .85 1.8")</pose>
     <view_controller>orbit</view_controller>
   </camera>
 </gui>

--- a/burger_war/world/burger_field.world.em
+++ b/burger_war/world/burger_field.world.em
@@ -13,7 +13,7 @@
 
 <gui>
   <camera name="camera">
-    <pose>1.5 -5. 6. 0.0 .85 1.8</pose>
+    <pose>-0.03 0.13 2.76 0.0 1.57 2.26</pose>
     <view_controller>orbit</view_controller>
   </camera>
 </gui>

--- a/burger_war/world/burger_field.world.em
+++ b/burger_war/world/burger_field.world.em
@@ -13,7 +13,7 @@
 
 <gui>
   <camera name="camera">
-    <pose>-0.03 0.13 2.76 0.0 1.57 2.26</pose>
+    <pose>1.5 -5. 6. 0.0 .85 1.8</pose>
     <view_controller>orbit</view_controller>
   </camera>
 </gui>

--- a/burger_war/world/burger_field_autotest.world
+++ b/burger_war/world/burger_field_autotest.world
@@ -1,0 +1,515 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+<world name="onigiri_field">
+
+<scene>
+  <shadows>false</shadows>
+</scene>
+
+<physics name="ode_100iters" type="ode">
+  <real_time_update_rate>1000</real_time_update_rate>
+  <max_step_size>0.001</max_step_size>
+</physics>
+
+<gui>
+  <camera name="camera">
+    <pose>-0.03 0.13 2.76 0.0 1.57 2.26</pose>
+    <view_controller>orbit</view_controller>
+  </camera>
+</gui>
+<include><uri>model://sun</uri></include>
+<include><uri>model://my_ground_plane</uri></include>
+
+
+
+<!-- Centor BOX -->
+<include>
+  <name>box_0</name>
+  <pose>0 0 0.1 0 0 0</pose>
+  <uri>model://center_box</uri>
+</include>
+<include>
+  <name>plate_1</name>
+  <pose>0 0.1755 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_0_tag_1">
+  <static>true</static>
+  <pose>0 0.176 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri> <name>0001</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+<include>
+  <name>plate_2</name>
+  <pose>0 -0.1755 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_0_tag_2">
+  <static>true</static>
+  <pose>0 -0.176 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0002</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+<include>
+  <name>plate_3</name>
+  <pose>0.1755 0 0.1 0 0 1.571</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_0_tag_3">
+  <static>true</static>
+  <pose>0.176 0 0.1 0 0 1.571</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0003</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+<include>
+  <name>plate_4</name>
+  <pose>-0.1755 0 0.1 0 0 1.571</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_0_tag_4">
+  <static>true</static>
+  <pose>-0.176 0 0.1 0 0 1.571</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0004</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+
+
+<!-- Corner BOX -->
+
+
+
+<include>
+  <name>box_1</name>
+  <pose>0.53 0.53 0.1 0 0 0</pose>
+  <uri>model://corner_box</uri>
+</include>
+<include>
+  <name>plate_5</name>
+  <pose>0.53 0.61 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_1_tag_5">
+  <static>true</static>
+  <pose>0.53 0.615 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0005</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+<include>
+  <name>plate_6</name>
+  <pose>0.53 0.45 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_1_tag_6">
+  <static>true</static>
+  <pose>0.53 0.445 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0006</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+
+
+<include>
+  <name>box_2</name>
+  <pose>0.53 -0.53 0.1 0 0 0</pose>
+  <uri>model://corner_box</uri>
+</include>
+<include>
+  <name>plate_7</name>
+  <pose>0.53 -0.45 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_2_tag_7">
+  <static>true</static>
+  <pose>0.53 -0.445 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0007</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+<include>
+  <name>plate_8</name>
+  <pose>0.53 -0.61 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_2_tag_8">
+  <static>true</static>
+  <pose>0.53 -0.615 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0008</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+
+
+
+
+<include>
+  <name>box_3</name>
+  <pose>-0.53 0.53 0.1 0 0 0</pose>
+  <uri>model://corner_box</uri>
+</include>
+<include>
+  <name>plate_9</name>
+  <pose>-0.53 0.61 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_3_tag_9">
+  <static>true</static>
+  <pose>-0.53 0.615 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0009</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+<include>
+  <name>plate_10</name>
+  <pose>-0.53 0.45 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_3_tag_10">
+  <static>true</static>
+  <pose>-0.53 0.445 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0010</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+
+
+<include>
+  <name>box_4</name>
+  <pose>-0.53 -0.53 0.1 0 0 0</pose>
+  <uri>model://corner_box</uri>
+</include>
+<include>
+  <name>plate_11</name>
+  <pose>-0.53 -0.45 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_4_tag_11">
+  <static>true</static>
+  <pose>-0.53 -0.445 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0011</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+<include>
+  <name>plate_12</name>
+  <pose>-0.53 -0.61 0.1 0 0 0</pose>
+  <uri>model://plate</uri>
+</include>
+<model name="box_4_tag_12">
+  <static>true</static>
+  <pose>-0.53 -0.615 0.1 0 0 0</pose>
+  <link name="link">
+    <visual name="visual">
+      <geometry><box><size>0.03 0.001 0.03</size></box></geometry>
+      <material>
+        <script>
+          <uri>model://tags</uri>
+          <name>0012</name>
+        </script>
+      </material>
+    </visual>
+  </link>
+</model>
+
+
+
+
+
+<!-- WALL -->
+
+
+
+
+
+  
+  
+  
+  
+  
+  
+  
+
+  <model name="wall_1">
+    <static>true</static>
+    <pose>0.8485 0.8485 0.15 0 0 -0.785398163397</pose>
+    <link name="link">
+      <collision name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+        <material>
+          <script>
+            <uri>model://wall</uri>
+            <name>wall_1</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+
+
+  
+  
+  
+  
+  
+  
+  
+
+  <model name="wall_2">
+    <static>true</static>
+    <pose>0.8485 -0.8485 0.15 0 0 -2.35619449019</pose>
+    <link name="link">
+      <collision name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+        <material>
+          <script>
+            <uri>model://wall</uri>
+            <name>wall_2</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+
+
+  
+  
+  
+  
+  
+  
+  
+
+  <model name="wall_3">
+    <static>true</static>
+    <pose>-0.8485 -0.8485 0.15 0 0 2.35619449019</pose>
+    <link name="link">
+      <collision name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+        <material>
+          <script>
+            <uri>model://wall</uri>
+            <name>wall_3</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+
+
+  
+  
+  
+  
+  
+  
+  
+
+  <model name="wall_4">
+    <static>true</static>
+    <pose>-0.8485 0.8485 0.15 0 0 0.785398163397</pose>
+    <link name="link">
+      <collision name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name='visual'>
+        <geometry>
+          <box>
+            <size>2.39992041535 0.0001 0.3</size>
+          </box>
+        </geometry>
+        <material>
+          <script>
+            <uri>model://wall</uri>
+            <name>wall_4</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+
+
+<!-- RED and BLUE maker -->
+<model name="blue_maker">
+  <static>true</static>
+  <link name="link">
+    <visual name="visual">
+      <pose>0 3 0 0 0 0</pose>
+      <geometry>
+        <cylinder>
+          <radius>0.3</radius>
+          <length>0.1</length>
+        </cylinder>
+      </geometry>
+      <material><script><name>Gazebo/Blue</name></script></material>
+    </visual>
+  </link>
+</model>
+<model name="red_maker">
+  <static>true</static>
+  <link name="link">
+    <visual name="visual">
+      <pose>0 -3 0 0 0 0</pose>
+      <geometry>
+        <cylinder>
+          <radius>0.3</radius>
+          <length>0.1</length>
+        </cylinder>
+      </geometry>
+      <material><script><name>Gazebo/Red</name></script></material>
+    </visual>
+  </link>
+</model>
+
+<!-- YELLOW disc invisible obstable -->
+<include>
+  <name>disc_0</name>
+  <pose>0.53 0 0.0025 0 0 0</pose>
+  <uri>model://disc</uri>
+</include>
+<include>
+  <name>disc_1</name>
+  <pose>-0.53 0 0.0025 0 0 0</pose>
+  <uri>model://disc</uri>
+</include>
+
+</world>
+</sdf>

--- a/burger_war/world/gen.sh
+++ b/burger_war/world/gen.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -o verbose
 empy burger_field.world.em > burger_field.world
+empy -DGUI_CAMERA_POSE='"-0.03 0.13 2.76 0.0 1.57 2.26"' burger_field.world.em > burger_field_autotest.world

--- a/scripts/capture.sh
+++ b/scripts/capture.sh
@@ -5,7 +5,7 @@
 #   $ sudo apt-get install -y ffmpeg
 
 # default value
-FPS=10           # capture frame per sec (ex.4)
+FPS=5           # capture frame per sec (ex.4)
 PLAYBACK_SPEED=1 # playback speed        (ex.8)
 CAPTURE_NAME="capture.mp4"
 MODE="start"
@@ -49,7 +49,7 @@ output_warning
 
 if [ $MODE == "start" ];then
     # capture start
-    gnome-terminal -- recordmydesktop --no-sound --no-cursor --fps ${FPS}
+    gnome-terminal -- recordmydesktop --no-sound --no-cursor --fps ${FPS} --width 1400 --height 1400
 
 elif [ $MODE == "stop" ];then
     #capture stop

--- a/scripts/sim_with_judge.sh
+++ b/scripts/sim_with_judge.sh
@@ -2,6 +2,16 @@
 set -e
 set -x
 
+declare IS_AUTOTEST="false"
+
+while getopts a OPT
+do
+  case $OPT in
+    "a" ) IS_AUTOTEST="true" ;;
+  esac
+done
+shift $((OPTIND - 1))
+
 # check arg num
 if [ $# -ne 2 ]; then
     RED_NAME="you"
@@ -23,5 +33,9 @@ gnome-terminal -- python judge/JudgeWindow.py
 bash judge/test_scripts/init_single_play.sh judge/marker_set/sim.csv localhost:5000  $RED_NAME $BLUE_NAME
 
 # robot
-roslaunch burger_war setup_sim.launch
-
+if [ "${IS_AUTOTEST}" = "true" ]; then
+    roslaunch burger_war setup_sim.launch \
+	      world_file:=$(rospack find burger_war)/world/burger_field_autotest.world
+else
+    roslaunch burger_war setup_sim.launch
+fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,13 +2,14 @@
 
 # set default level 1
 VALUE_L="1"
-
+IS_AUTOTEST="FALSE"
 
 # get args level setting
-while getopts l: OPT
+while getopts l:a OPT
 do
   case $OPT in
-    "l" ) FLG_L="TRUE" ; VALUE_L="$OPTARG" ;;
+      "l" ) FLG_L="TRUE" ; VALUE_L="$OPTARG" ;;
+      "a" ) IS_AUTOTEST="TRUE";;
   esac
 done
 
@@ -16,4 +17,8 @@ done
 bash judge/test_scripts/set_running.sh localhost:5000
 
 # launch robot control node
-roslaunch burger_war sim_robot_run.launch enemy_level:=$VALUE_L
+declare -a ROSLAUNCH_OPTIONS=("enemy_level:=${VALUE_L}")
+if [ "${IS_AUTOTEST}" = "TRUE" ]; then
+    ROSLAUNCH_OPTIONS+=("rviz_file:=burger_navigation_autotest.rviz")
+fi
+roslaunch burger_war sim_robot_run.launch ${ROSLAUNCH_OPTIONS[@]}


### PR DESCRIPTION
@seigot 
デフォルトのカメラのポジションが遠くて録画時に見づらいので、変えませんか？
ちょっと無機質ですが真上が一番わかりよいかなぁとおもって真上にしてみました。
もうちょっと臨場感的なものがほしければ角度斜めのままカメラを寄せるという手もあるかと思います（影ができちゃうので解析用には向かないと思いますが汗）。
ご意見ください。このPRのままで良ければmergeお願いします。

![Screenshot from 2021-02-15 16-53-44](https://user-images.githubusercontent.com/3068739/107919362-86b60300-6fae-11eb-8d6f-7d48e2a9ff84.png)

ちなみに、釈迦に説法かもですが、gazeboのカメラ位置は、
`World`タブの`GUI`の中の`camera`>`pose`から確認できました。